### PR TITLE
Fixup tests

### DIFF
--- a/examples/checker_tests/good/issue1208-1.p4
+++ b/examples/checker_tests/good/issue1208-1.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include "../p4include/psa.p4"
+#include <psa.p4>
 struct EMPTY { };
 
 parser MyIP(

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -31,8 +31,15 @@ module Make_parse (Conf: Parse_config) = struct
     let lexbuf = Lexing.from_string p4_string in
     try
       let prog = Parser.p4program Lexer.lexer lexbuf in
-      if verbose then Format.eprintf "[%s] %s@\n%!" (Conf.green "Passed") p4_file;
+      if verbose then 
+        begin 
+          Format.eprintf "[%s] %s@\n%!" (Conf.green "Passed") p4_file;
+          Format.printf "%a@\n%!" Pretty.format_program prog;
+          Format.printf "----------@\n";
+          Format.printf "%s@\n%!" (prog |> Types.program_to_yojson |> Yojson.Safe.pretty_to_string)
+        end;
       `Ok prog
+
     with
     | err ->
       if verbose then Format.eprintf "[%s] %s@\n%!" (Conf.red "Failed") p4_file;

--- a/lib/error.ml
+++ b/lib/error.ml
@@ -13,6 +13,21 @@ type error =
   | UnreachableBlock
 [@@deriving sexp]
 
+let format_error fmt = function
+  | Unbound x -> 
+     Format.fprintf fmt "error: %s unbound" x
+  | Mismatch { expected; found } -> 
+     Format.fprintf fmt "error: type mismatch, expected %s but found <...>" 
+       expected
+  | UnfoundMember { expected_member } -> 
+     Format.fprintf fmt "error: no such member %s" expected_member
+  | Type_Difference(t1,t2) -> 
+     Format.fprintf fmt "error: different types <...> and <...>"
+  | Duplicate -> 
+     Format.fprintf fmt "error: duplicate"
+  | UnreachableBlock -> 
+     Format.fprintf fmt "error: unreachable block"
+     
 exception Internal of string [@@deriving sexp]
 exception Type of (Info.t * error) [@@deriving sexp]
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -21,12 +21,12 @@ type 'a info = Info.t * 'a [@@deriving sexp,yojson]
 
 let info (i,_) = i
 
-(* let info_to_yojson f (_,x) = f x
- *
- * let info_of_yojson f json =
- *   match f json with
- *   | Ok pre -> Ok (Info.M "<yojson>", pre)
- *   | Error x -> Error x *)
+let info_to_yojson f (_,x) = f x
+
+let info_of_yojson f json =
+  match f json with
+  | Ok pre -> Ok (Info.M "<yojson>", pre)
+  | Error x -> Error x
 
 module P4Int = struct
 

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,5 @@
 (tests
-(names test)
-(libraries core p4pp petr4 alcotest)
-(action (run %{test} -e)))
+  (names test)
+  (libraries core p4pp petr4 alcotest)
+  (deps (source_tree ../examples))
+  (action (run %{test} -e)))


### PR DESCRIPTION
* Add `examples` as a Dune dependency

* Remove commands to change directories in `Test`

* Add `example_path` helper function to construct paths

* Add exception handling to avoid voluminous printouts on failed typechecking tests.

* Fix bad reference to `psa.p4` in `issue1208-1.p4`