### PR TITLE
Streamline realTypeArgList in parser

### DIFF
--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -819,14 +819,9 @@ typeArgumentList:
 | ts = separated_list(COMMA, typeArg) {ts}
 ;
 
-realTypeArgumentListAux:
-| t = realTypeArg { [t] }
-| ts = realTypeArgumentListAux COMMA t = typeArg { t::ts }
-;
-
 realTypeArgumentList:
-| rev_ts = realTypeArgumentListAux
-    { List.rev rev_ts }
+| t = realTypeArg { [t] }
+| t = realTypeArg COMMA ts = separated_list(COMMA, typeArg) { t :: ts }
 ;
 
 typeDeclaration:


### PR DESCRIPTION
Use our standard helper functions for parsing lists rather than a custom production for `realTypeArgList`