### PR TITLE
Finish compile time evaluation (without instantiations)

### DIFF
--- a/examples/checker_tests/good/issue1717.p4
+++ b/examples/checker_tests/good/issue1717.p4
@@ -1,5 +1,5 @@
 header H {
-    bit<32> is_valid;
+    bit<32> isValid;
 }
 
 type bit<32> T;
@@ -9,8 +9,8 @@ enum bit<16> E {
 
 header H1 {
     bit<16> f;
-    bit<8> min_size_in_bits;
-    bit<8> min_size_in_bytes;
+    bit<8> minSizeInBytes;
+    bit<8> minSizeInBits;
     T f1;
     E e;
 }
@@ -45,11 +45,11 @@ bool v(in HU h) {
     Nested n;
     S s;
     const bool b = h.minSizeInBits() == 32;
-    bool b1 = h.h2.min_size_in_bits == 32;
+    bool b1 = h.h2.minSizeInBits == 32;
     const bit<32> se = e.minSizeInBits() + n.minSizeInBits() + s.h3.minSizeInBytes();
     const bit<32> sz = h.h1.minSizeInBits() + h.h2.minSizeInBits() + h.h2.minSizeInBytes();
     return h.isValid() &&
-    h.h1.is_valid == 0 &&
+    h.h1.isValid == 0 &&
     b &&
     b1 &&
     h.h2.minSizeInBits() < (5 + h.h1.minSizeInBits()) &&

--- a/examples/checker_tests/good/issue1717.p4
+++ b/examples/checker_tests/good/issue1717.p4
@@ -1,5 +1,5 @@
 header H {
-    bit<32> isValid;
+    bit<32> is_valid;
 }
 
 type bit<32> T;
@@ -9,8 +9,8 @@ enum bit<16> E {
 
 header H1 {
     bit<16> f;
-    bit<8> minSizeInBytes;
-    bit<8> minSizeInBits;
+    bit<8> min_size_in_bits;
+    bit<8> min_size_in_bytes;
     T f1;
     E e;
 }
@@ -45,11 +45,11 @@ bool v(in HU h) {
     Nested n;
     S s;
     const bool b = h.minSizeInBits() == 32;
-    bool b1 = h.h2.minSizeInBits == 32;
+    bool b1 = h.h2.min_size_in_bits == 32;
     const bit<32> se = e.minSizeInBits() + n.minSizeInBits() + s.h3.minSizeInBytes();
     const bit<32> sz = h.h1.minSizeInBits() + h.h2.minSizeInBits() + h.h2.minSizeInBytes();
     return h.isValid() &&
-    h.h1.isValid == 0 &&
+    h.h1.is_valid == 0 &&
     b &&
     b1 &&
     h.h2.minSizeInBits() < (5 + h.h1.minSizeInBits()) &&

--- a/lib/checker.ml
+++ b/lib/checker.ml
@@ -74,11 +74,20 @@ let rec compile_time_eval_expr (env: CheckerEnv.t) (expr: Prog.Expression.t) : P
         then Some (Prog.Value.VInt { w = Bigint.of_int width; v = i.value })
         else Some (Prog.Value.VBit { w = Bigint.of_int width; v = i.value })
      end
-  | UnaryOp { op; arg } -> failwith "unimplemented"
-  | BinaryOp { op; args } -> failwith "unimplemented"
+  | UnaryOp { op; arg } ->
+     begin match compile_time_eval_expr env arg with
+     | Some arg ->
+        Some (Ops.interp_unary_op op arg)
+     | None -> None
+     end
+  | BinaryOp { op; args = (l, r) } ->
+     begin match compile_time_eval_expr env l,
+                 compile_time_eval_expr env r with
+     | Some l, Some r ->
+        Some (Ops.interp_binary_op op l r)
+     | _ -> None
+     end
   | Cast { typ; expr } -> compile_time_eval_expr env expr
-  | TypeMember {typ; name } -> failwith "unimplemented"
-  | Ternary {cond; tru; fls } -> failwith "unimplemented"
   | List { values } ->
      begin match compile_time_eval_exprs env values with 
      | Some vals -> Some (VTuple vals)

--- a/lib/typed.ml
+++ b/lib/typed.ml
@@ -151,6 +151,7 @@ and EnumType : sig
   type t =
     { name: string;
       typ: Type.t option;
+      (* TODO remove this *)
       members: string list; }
     [@@deriving sexp,yojson]
 end = struct


### PR DESCRIPTION
This will close #72. I have unary ops and binary ops working but I need to finish with

- [x] error, match_kind members
- [x] enum and serializable enum members
- [x] universal sets "default", "_"
- [x] hs.size for header stacks hs
- [x] e.minSizeInBits() / e.minSizeInBytes() for headers
- [x] bitslices x[hi:lo]