### PR TITLE
Allow bitslice of int

### DIFF
--- a/lib/checker.ml
+++ b/lib/checker.ml
@@ -1103,6 +1103,7 @@ and is_numeric (typ: Typed.Type.t) : bool =
 and type_bit_string_access env bits lo hi : Prog.Expression.typed_t =
   let bits_typed = type_expression env bits in
   match reduce_type env (snd bits_typed).typ with
+  | Int { width }
   | Bit { width } ->
      let lo_typed = type_expression env lo in
      let typ_lo = saturate_type env (snd lo_typed).typ in

--- a/lib/checker.ml
+++ b/lib/checker.ml
@@ -1126,7 +1126,9 @@ and type_bit_string_access env bits lo hi : Prog.Expression.typed_t =
        typ = Bit { width = diff };
        dir = (snd bits_typed).dir }
   | typ ->
-     raise_s [%message "expected bit type, got" ~typ:(typ: Typed.Type.t)]
+     raise_s [%message "expected bit type, got"
+                 ~expr:(bits: Types.Expression.t)
+                 ~typ:(typ: Typed.Type.t)]
 
 (* Section 8.11
  * ------------
@@ -2374,10 +2376,11 @@ and type_constant env decl_info annotations typ name expr : Prog.Declaration.t *
   | Some value ->
      (decl_info, Constant { annotations; typ = expected_typ; name = name; value = value }),
      env
-     |> CheckerEnv.insert_dir_type_of (BareName name) (snd typed_expr).typ In
+     |> CheckerEnv.insert_dir_type_of (BareName name) expected_typ In
      |> CheckerEnv.insert_const (BareName name) value
   | None ->
-     failwith "expression not compile-time-known"
+     raise_s [%message "expression not compile-time-known"
+                 ~expr:(typed_expr:Prog.Expression.t)]
 
 and insert_params (env: CheckerEnv.t) (params: Types.Parameter.t list) : CheckerEnv.t =
   let open Types.Parameter in

--- a/triage/failures.csv
+++ b/triage/failures.csv
@@ -1,9 +1,8 @@
 Kind of test,Test p4 file,Explanation for failure,Github issue number
-checker,examples/checker_tests/good/constsigned.p4,bitslice of int<> values (bad test?),123
+checker,examples/checker_tests/good/constsigned.p4,compile time eval not evaluating casts,126
 checker,examples/checker_tests/good/type-params.p4,don't care as type parameter,80
 checker,examples/checker_tests/good/psa-portid-using-newtype2.p4,binop typecheck isn't saturating types before running,124
 checker,examples/checker_tests/good/action-two-params.p4,apparent coercion t <-> tuple<t> in set context,125
-checker,examples/checker_tests/good/names.p4,cast to struct not being done in const list initializer,126
 checker,examples/checker_tests/good/unused.p4,don't care as type parameter,80
 checker,examples/checker_tests/good/arch1.p4,don't care as type parameter,80
 checker,examples/checker_tests/good/issue1937-2-bmv2.p4,optional arguments,73
@@ -18,7 +17,6 @@ checker,examples/checker_tests/good/twoPipe.p4,don't care type as type parameter
 checker,examples/checker_tests/good/default-switch.p4,default allowed to not be last label (bad test),128
 checker,examples/checker_tests/good/issue803-2.p4,don't care type as type parameter,80
 checker,examples/checker_tests/good/enum-folding.y4,type member getting saturated,129
-checker,examples/checker_tests/good/issue1713-bmv2.p4,bit slice on integers,123
 checker,examples/checker_tests/good/newtype.p4,cast into new type not allowed,130
 checker,examples/checker_tests/good/issue1937-1-bmv2.p4,default arguments,73
 checker,examples/checker_tests/good/list-compare.p4,equality for tuples,131


### PR DESCRIPTION
I tried to fix constsigned.p4 but it turns out it requires evaluating casts at compile time, which seems like a separate diff. This made a few tests start passing. Closes #123.