### PR TITLE
Hashing externs

### DIFF
--- a/lib/p4core.ml
+++ b/lib/p4core.ml
@@ -160,7 +160,7 @@ module Corize (T : Target) : Target = struct
     | Enum {typ = Some t;_} -> val_of_bigint env t n
     | TypeName name -> val_of_bigint env (EvalEnv.find_typ name env) n
     | NewType nt -> val_of_bigint env nt.typ n
-    | _ -> failwith "not a fixed-width type"
+    | _ -> raise_s [%message "not a fixed-width type" ~t:(t: Type.t)]
     
   let eval_lookahead : extern = fun _ env st targs args ->
     let t = match targs with

--- a/lib/target.ml
+++ b/lib/target.ml
@@ -24,6 +24,7 @@ let rec width_of_typ (env : env) (t : Type.t) : Bigint.t =
   | Bool -> Bigint.one
   | Int {width} | Bit {width} -> Bigint.of_int width
   | Array {typ;size} -> Bigint.(width_of_typ env typ * of_int size)
+  | List {types}
   | Tuple {types} ->
     types
     |> List.map ~f:(width_of_typ env)
@@ -36,7 +37,7 @@ let rec width_of_typ (env : env) (t : Type.t) : Bigint.t =
   | Enum {typ = Some t;_} -> width_of_typ env t
   | TypeName n -> width_of_typ env (EvalEnv.find_typ n env)
   | NewType nt -> width_of_typ env nt.typ
-  | _ -> failwith "not a fixed-width type"
+  | _ -> raise_s [%message "not a fixed-width type" ~t:(t:Type.t)]
 
 let rec init_val_of_typ (env : env) (typ : Type.t) : value =
   match typ with

--- a/lib/v1model.ml
+++ b/lib/v1model.ml
@@ -273,8 +273,8 @@ module PreV1Switch : Target = struct
 
   let eval_hash : extern = fun ctrl env st ts args ->
     let width = match ts with
-      | [o; _] -> width_of_typ env o
-      | _ -> failwith "unexpected type args for hash" in
+      | o :: _ -> width_of_typ env o
+      | _ -> failwith "missing type args for hash" in
     let (algo, base, data, rmax) = match args with
       | [_; (VEnumField {enum_name=algo;_}, _);
         (VBit{w=base;_},_); (VTuple data, _); (VBit{v=max;_}, _)] ->

--- a/lib/v1model.ml
+++ b/lib/v1model.ml
@@ -264,7 +264,7 @@ module PreV1Switch : Target = struct
   let package_for_hash (data : value list) : Bigint.t * Bigint.t =
     data
     |> List.map ~f:(fun v -> width_of_val v, bigint_of_val v)
-    |> List.map ~f:(fun (w,v) -> w, Bitstring.of_twos_complement w v)
+    |> List.map ~f:(fun (w,v) -> w, Bitstring.of_twos_complement v w)
     |> List.fold ~init:Bigint.(zero,zero) ~f:(fun (accw, accv) (nw, nv) ->
         Bigint.(accw + nw, Bitstring.shift_bitstring_left accv nw + nv))
 

--- a/lib/v1model.ml
+++ b/lib/v1model.ml
@@ -10,6 +10,8 @@ module Info = I
 
 module PreV1Switch : Target = struct
 
+  exception V1ChecksumError
+
   let drop_spec = Bigint.of_int 511
 
   type obj =
@@ -218,19 +220,19 @@ module PreV1Switch : Target = struct
       assign_lvalue env lv (VBit {v = drop_spec; w = Bigint.of_int 9}) in
     env', st, SContinue, VNull
 
-  let hash_crc32 (length : Bigint.t) (v : Bigint.t) : Bigint.t =
+  let hash_crc32 (length, v : Bigint.t * Bigint.t) : Bigint.t =
     failwith "TODO: implement hash algorithm"
 
-  let hash_crc32_custom (length : Bigint.t) (v : Bigint.t) : Bigint.t =
+  let hash_crc32_custom (length, v : Bigint.t * Bigint.t) : Bigint.t =
     failwith "TODO: implement hash algorithm"
 
-  let hash_crc16 (length : Bigint.t) (v : Bigint.t) : Bigint.t =
+  let hash_crc16 (length, v : Bigint.t * Bigint.t) : Bigint.t =
     failwith "TODO: implement hash algorithm"
 
-  let hash_crc16_custom (length : Bigint.t) (v : Bigint.t) : Bigint.t =
+  let hash_crc16_custom (length, v : Bigint.t * Bigint.t) : Bigint.t =
     failwith "TODO: implement hash algorithm"
 
-  let hash_random (length : Bigint.t) (v : Bigint.t) : Bigint.t =
+  let hash_random (length, v : Bigint.t * Bigint.t) : Bigint.t =
     Bigint.to_string v
     |> String.to_list
     |> List.map ~f:Char.to_int
@@ -238,16 +240,16 @@ module PreV1Switch : Target = struct
     |> Random.full_init; (* Obj.magic instead??? *)
     Random.int 256 |> Bigint.of_int
 
-  let hash_identity (length : Bigint.t) (v : Bigint.t) : Bigint.t =
+  let hash_identity (length, v : Bigint.t * Bigint.t) : Bigint.t =
     v
 
-  let hash_csum16 (length : Bigint.t) (v : Bigint.t) : Bigint.t =
+  let hash_csum16 (length, v : Bigint.t * Bigint.t) : Bigint.t =
     failwith "TODO: implement hash algorithm"
 
-  let hash_xor16 (length : Bigint.t) (v : Bigint.t) : Bigint.t =
+  let hash_xor16 (length, v : Bigint.t * Bigint.t) : Bigint.t =
     failwith "TODO: implement hash algorithm"
 
-  let hash (algo : string) : Bigint.t -> Bigint.t -> Bigint.t =
+  let hash (algo : string) : (Bigint.t * Bigint.t) -> Bigint.t =
     match algo with
     | "crc32"        -> hash_crc32
     | "crc32_custom" -> hash_crc32_custom
@@ -259,6 +261,16 @@ module PreV1Switch : Target = struct
     | "xor16"        -> hash_xor16
     | _              -> failwith "unknown hash algorithm"
 
+  let package_for_hash (data : value list) : Bigint.t * Bigint.t =
+    data
+    |> List.map ~f:(fun v -> width_of_val v, bigint_of_val v)
+    |> List.map ~f:(fun (w,v) -> w, Bitstring.of_twos_complement w v)
+    |> List.fold ~init:Bigint.(zero,zero) ~f:(fun (accw, accv) (nw, nv) ->
+        Bigint.(accw + nw, Bitstring.shift_bitstring_left accv nw + nv))
+
+  let adjust_hash_value : Bigint.t -> Bigint.t -> Bigint.t -> Bigint.t =
+    fun base rmax hv -> Bigint.(hv % rmax + base)
+
   let eval_hash : extern = fun ctrl env st ts args ->
     let width = match ts with
       | [o; _] -> width_of_typ env o
@@ -268,21 +280,12 @@ module PreV1Switch : Target = struct
         (VBit{w=base;_},_); (VTuple data, _); (VBit{v=max;_}, _)] ->
         algo, base, data, max
       | _ -> failwith "unexpected args for hash" in
-    let bigints = 
+    let result = 
       data
-      |> List.map ~f:bigint_of_val in
-    let widths = List.map ~f:width_of_val data in
-    let vs = List.zip_exn widths bigints in
-    let vs' = List.map vs ~f:(fun (w,v) -> w, Bitstring.of_twos_complement w v) in
-    let combined_width, combined_value = 
-      List.fold vs'
-        ~init:Bigint.(zero,zero)
-        ~f:(fun (accw, accv) (nw, nv) ->
-          Bigint.(accw + nw, Bitstring.shift_bitstring_left accv nw + nv)) in
-    let result = hash algo combined_width combined_value in
-    let result_mod = Bigint.(result % rmax) in
-    let final_result = Bigint.(result_mod + base) in
-    let env = EvalEnv.insert_val_bare "result" (VBit{w=width; v=final_result}) env in
+      |> package_for_hash
+      |> hash algo
+      |> adjust_hash_value base rmax in
+    let env = EvalEnv.insert_val_bare "result" (VBit{w=width; v=result}) env in
     env, st, SContinue, VNull
 
   let eval_action_selector : extern = fun ctrl env st ts args ->
@@ -305,24 +308,99 @@ module PreV1Switch : Target = struct
     (* TODO: actually implement *)
     env, st, SContinue, VBit{w=Bigint.of_int 32; v=Bigint.zero}
 
-  let eval_verify_checksum : extern = fun _ -> failwith "TODO: verify"
+  let eval_verify_checksum : extern = fun ctrl env st ts args ->
+    let width = match ts with
+      | _ :: o :: _ -> width_of_typ env o
+      | _ -> failwith "unexpected type args for verify checksum" in
+    let (condition, data, checksum, algo) = match args with
+      | [(VBool condition,_); (VTuple data, _);
+        (VBit{v;_}, _); (VEnumField{enum_name;_},_)] ->
+        condition, data, v, enum_name
+      | _ -> failwith "unexpected args for verify checksum" in
+    if not condition then env, st, SContinue, VNull else
+    let result = 
+      data
+      |> package_for_hash
+      |> hash algo
+      |> adjust_hash_value Bigint.zero (Bitstring.power_of_two width) in
+    if Bigint.(checksum = result) then env, st, SContinue, VNull
+    else raise V1ChecksumError
 
-  let eval_update_checksum : extern = fun _ -> failwith "TODO: update"
+  let eval_update_checksum : extern = fun ctrl env st ts args ->
+    let width = match ts with
+      | _ :: o :: _ -> width_of_typ env o
+      | _ -> failwith "unexpected type args for verify checksum" in
+    let (condition, data, checksum, algo) = match args with
+      | [(VBool condition,_); (VTuple data, _);
+        (VBit{v;_}, _); (VEnumField{enum_name;_},_)] ->
+        condition, data, v, enum_name
+      | _ -> failwith "unexpected args for verify checksum" in
+    if not condition then env, st, SContinue, VNull else
+    let result = 
+      data
+      |> package_for_hash
+      |> hash algo
+      |> adjust_hash_value Bigint.zero (Bitstring.power_of_two width) in
+    let env' = EvalEnv.insert_val_bare "checksum" (VBit{w=width;v=result}) env in
+    env', st, SContinue, VNull
 
-  let eval_verify_checksum_with_payload : extern = fun _ -> failwith "TODO: verify with payload"
+  let value_of_payload (st : state) : value = 
+    VBit { w = Bigint.zero; v = Bigint.zero }
 
-  let eval_update_checksum_with_payload : extern = fun _ -> failwith "TODO: update with payload"
+  let eval_verify_checksum_with_payload : extern = fun ctrl env st ts args ->
+    let width = match ts with
+      | _ :: o :: _ -> width_of_typ env o
+      | _ -> failwith "unexpected type args for verify checksum" in
+    let (condition, data, checksum, algo) = match args with
+      | [(VBool condition,_); (VTuple data, _);
+        (VBit{v;_}, _); (VEnumField{enum_name;_},_)] ->
+        condition, data, v, enum_name
+      | _ -> failwith "unexpected args for verify checksum" in
+    if not condition then env, st, SContinue, VNull else
+    let payload_value = value_of_payload st in (* TODO *)
+    let data = payload_value :: data in
+    let result = 
+      data
+      |> package_for_hash
+      |> hash algo
+      |> adjust_hash_value Bigint.zero (Bitstring.power_of_two width) in
+    if Bigint.(checksum = result) then env, st, SContinue, VNull
+    else raise V1ChecksumError
+
+  let eval_update_checksum_with_payload : extern = fun ctrl env st ts args ->
+    let width = match ts with
+      | _ :: o :: _ -> width_of_typ env o
+      | _ -> failwith "unexpected type args for verify checksum" in
+    let (condition, data, checksum, algo) = match args with
+      | [(VBool condition,_); (VTuple data, _);
+        (VBit{v;_}, _); (VEnumField{enum_name;_},_)] ->
+        condition, data, v, enum_name
+      | _ -> failwith "unexpected args for verify checksum" in
+    if not condition then env, st, SContinue, VNull else
+    let payload_value = value_of_payload st in (* TODO *)
+    let data = payload_value :: data in
+    let result = 
+      data
+      |> package_for_hash
+      |> hash algo
+      |> adjust_hash_value Bigint.zero (Bitstring.power_of_two width) in
+    let env' = EvalEnv.insert_val_bare "checksum" (VBit{w=width;v=result}) env in
+    env', st, SContinue, VNull
 
   let eval_resubmit : extern = fun ctrl env st ts args ->
+    (* TODO: actually implement *)
     env, st, SContinue, VNull
 
   let eval_recirculate : extern = fun ctrl env st ts args ->
+    (* TODO: actually implement *)
     env, st, SContinue, VNull
 
   let eval_clone : extern = fun ctrl env st ts args ->
+    (* TODO: actually implement *)
     env, st, SContinue, VNull
 
   let eval_clone3 : extern = fun ctrl env st ts args ->
+    (* TODO: actually implement *)
     env, st, SContinue, VNull
 
   let eval_truncate : extern = fun ctrl env st ts args ->
@@ -418,6 +496,8 @@ module PreV1Switch : Target = struct
         - checks that the write T is a bit<W> type.
         - checks that the random T is a bit<W> type.
         - checks all the constraints on the hash arg types.
+        - checks all the constraints on the verify_checksum(_with_payload) arg types.
+        - checks all the constraints on the update_checksum(_with_payload) arg types.
         - checks that verify and update checksum controls only do certain
           kinds of statements/expressions. *)
 
@@ -507,9 +587,17 @@ module PreV1Switch : Target = struct
     let vpkt' = VRuntime { loc = State.packet_location; obj_name = "packet_out"; } in
     let env = EvalEnv.insert_val (BareName (Info.dummy, "packet")) vpkt' env in
     let env = EvalEnv.insert_typ (BareName (Info.dummy, "packet")) (snd (List.nth_exn deparse_params 0)).typ env in
-    let (env,st) = 
+    let (env,st) = try 
       (env,st)
       |> eval_v1control ctrl app "vr."  verify   [hdr_expr; meta_expr] |> fst23
+    with V1ChecksumError ->
+      assign_lvalue
+        env
+        {lvalue = LMember{expr={lvalue = LName{name = Types.BareName (Info.dummy, "std_meta")};typ = (snd (List.nth_exn params 3)).typ}; 
+                name="checksum_error"; }; typ = Bit {width = 1}}
+        (VBit{v=Bigint.one;w=Bigint.one}) |> fst,
+      st in
+    let env, st = (env, st)
       |> eval_v1control ctrl app "ig."  ingress  [hdr_expr; meta_expr; std_meta_expr] |> fst23 in
     let struc = EvalEnv.find_val (BareName (Info.dummy, "std_meta")) env in
     let egress_spec_val = match struc with

--- a/triage/failures.csv
+++ b/triage/failures.csv
@@ -99,18 +99,17 @@ stf,examples/checker_tests/good/issue1814-1-bmv2.p4,STF parser crash (add) and r
 stf,examples/checker_tests/good/ipv6-switch-ml-bmv2.p4,STF parser crash (mc_node_create, etc),156
 stf,examples/checker_tests/good/v1model-special-ops-bmv2.p4,STF parser crash (mc_mgrp_create, add),156
 stf,examples/checker_tests/good/key-bmv2.p4,STF parser crash,156
-stf,examples/checker_tests/good/checksum3-bmv2.p4,update_checksum extern unimplemented,109
-stf,examples/checker_tests/good/issue655-bmv2.p4,verify_checksum extern unimplemented,109
+stf,examples/checker_tests/good/checksum3-bmv2.p4,List not a fixed-width type,
+stf,examples/checker_tests/good/issue655-bmv2.p4,List not a fixed-width type,
 stf,examples/checker_tests/good/issue1768-bmv2.p4,mark_to_drop extern unimplemented,109
 stf,examples/checker_tests/good/constant-in-calculation-bmv2.p4,hash extern unimplemented,109
 stf,examples/checker_tests/good/issue1049-bmv2.p4,hash extern unimplemented,109
 stf,examples/checker_tests/good/checksum2-bmv2.p4,verify_checksum extern unimplemented,109
-stf,examples/checker_tests/good/checksum1-bmv2.p4,verify_checksum extern unimplemented,109
 stf,examples/checker_tests/good/parser_error-bmv2.p4,struct.hdr_field.setValid() fails in eval_setbool,158
 stf,examples/checker_tests/good/issue510-bmv2.p4,struct.hdr_field.setValid() fails in eval_setbool,158
 stf,examples/checker_tests/good/table-entries-ser-enum-bmv2.p4,width of serializable enum unimplemented,159
-stf,examples/checker_tests/good/bvec-hdr-bmv2.p4,width of struct unimplemented,159
 stf,examples/checker_tests/good/header-bool-bmv2.p4,width of bool and bool extraction unimplemented (spec 7.2.2 has a full list of fields allowed in hdrs),159
+stf,examples/checker_tests/good/checksum1-bmv2.p4,lookahead (val_of_bigint) unimplemented for header types,160
 stf,examples/checker_tests/good/issue1025-bmv2.p4,lookahead (val_of_bigint) unimplemented for header types,160
 stf,examples/checker_tests/good/extern-funcs-bmv2.p4,uninterpreted extern function supposed to assign (bad test? missing data?),161
 stf,examples/checker_tests/good/issue774-4-bmv2.p4,passing dontcare as an out argument causes crash,173


### PR DESCRIPTION
Implemented externs hash, verify_checksum[_with_payload], and update_checksum[_with_payload]. Implemented hashing algorithms identity and random with the rest stubbed out. Looking for a sanity check on my mental model for how targets do hashing.

Note: it will not appear in the diff, but the implementation of 'eval_hash` starting on line 274 is part of this PR - I accidentally pushed the first commit to master.