### PR TITLE
Fix STF tests

### DIFF
--- a/stf-test/custom-stf-tests/scope.p4
+++ b/stf-test/custom-stf-tests/scope.p4
@@ -1,0 +1,68 @@
+/*
+Copyright 2016 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+typedef standard_metadata_t std_meta_t;
+
+header h_t { 
+  bit<8> x;
+}
+
+struct H { 
+  h_t h;
+}
+
+struct M { 
+}
+
+parser ParserI(packet_in pk, out H hdr, inout M meta, inout std_meta_t std_meta) {
+    state start {
+        pk.extract(hdr.h);
+        transition accept;
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply { }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply { }
+}
+
+action g(inout bit<8> b) { b = ~b; }
+
+action f(inout bit<8> b) { g(b); }
+
+control IngressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
+  action g(inout bit<8> b) { b = 0x99; }
+  apply {
+    f(hdr.h.x);
+  }
+}
+
+control EgressI(inout H hdr, inout M meta, inout std_meta_t std_meta) {
+    apply { }
+}
+
+control DeparserI(packet_out b, in H hdr) {
+    apply {
+        b.emit(hdr.h);
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/stf-test/custom-stf-tests/scope.p4
+++ b/stf-test/custom-stf-tests/scope.p4
@@ -1,19 +1,3 @@
-/*
-Copyright 2016 VMware, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 #include <core.p4>
 #include <v1model.p4>
 typedef standard_metadata_t std_meta_t;

--- a/stf-test/custom-stf-tests/scope.stf
+++ b/stf-test/custom-stf-tests/scope.stf
@@ -1,0 +1,2 @@
+packet 0 FF
+expect 0 00

--- a/stf-test/test.ml
+++ b/stf-test/test.ml
@@ -84,7 +84,9 @@ let run_test dirs name stmts =
             | `Error(info, exn) -> Some("")
             | `Ok(pkt, port) -> Some("")) *)
         in
-        let expected = List.filter_map ~f:(function Expect(port, Some(packet)) -> Some(port, strip_spaces packet) | _ -> None) stmts in
+        let expected = List.filter_map ~f:(function Expect(port, Some(packet)) -> Some(port, strip_spaces packet |> String.lowercase) 
+                                                  | _ -> None
+                         ) stmts in
         List.zip_exn expected results |> List.iter ~f:(fun (p_exp, p) ->
           Alcotest.(testable (Fmt.pair ~sep:Fmt.sp Fmt.string Fmt.string) packet_equal |> check) "packet test" p_exp p)
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -25,6 +25,15 @@ let parser_test include_dirs file =
   | `Ok _ -> true
   | `Error _ -> false
 
+let nate_test = 
+  match Parse.parse_file "scope.p4" with 
+  | `Ok prog -> 
+     let prog = Elaborate.elab prog in 
+     let prog = Checker.check_program prog in 
+     
+     
+  | `Error _ -> false
+
 let typecheck_test (include_dirs : string list) (p4_file : string) : bool =
   match Parse.parse_file include_dirs p4_file false with
   | `Ok prog ->


### PR DESCRIPTION
* The Alcotest predicate `packet_equal` was only checking the output port not the packet
* The STF test harness was confusingly inconsistent in how it represented port-packet pairs. We rationalized it to be (port,packet).
* Note: the STF test harness hides compilation errors -- it maps them to the empty list of packets, which could lead to bugs.
* And just to cap it all off, we currently implement dynamic scope :-/