### PR TITLE
Use poulet4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,15 @@ WEB_EXAMPLES+=examples/checker_tests/good/switch_ebpf.p4
 WEB_EXAMPLES+=examples/checker_tests/good/union-valid-bmv2.p4
 WEB_EXAMPLES+=stf-test/custom-stf-tests/register.p4
 
-.PHONY: all build claims clean test test-stf web
+.PHONY: all deps build claims clean test test-stf web
 
 all: build
 
-build:
+build: deps
 	dune build @install
+
+deps:
+	$(MAKE) -C deps
 
 doc:
 	dune build @doc

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1,0 +1,20 @@
+# Copyright 2019-present Cornell University
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+.PHONY: all poulet4
+
+all: poulet4
+
+poulet4:
+	$(MAKE) -C poulet4

--- a/deps/poulet4/.gitignore
+++ b/deps/poulet4/.gitignore
@@ -1,0 +1,16 @@
+Makefile.coq*
+.Makefile.coq*
+makefile
+makefile.conf
+*.vo*
+.*.aux
+*.glob
+*.v.d
+*~
+.coq-native/
+*.vio
+.coqdeps.d
+\#*.v\#
+.merlin
+extraction/lib/*.ml*
+_build

--- a/deps/poulet4/Makefile
+++ b/deps/poulet4/Makefile
@@ -1,0 +1,20 @@
+# This makefile is based on Karl Palmskog's "Coq Program Verification Template"
+# available at https://github.com/palmskog/coq-program-verification-template and
+# licensed under the MIT license.
+
+all: Makefile.coq
+	@+$(MAKE) -f Makefile.coq all
+
+clean: Makefile.coq
+	@+$(MAKE) -f Makefile.coq cleanall
+	@rm -f Makefile.coq Makefile.coq.conf
+
+Makefile.coq: _CoqProject
+	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
+
+force _CoqProject Makefile: ;
+
+%: Makefile.coq force
+	@+$(MAKE) -f Makefile.coq $@
+
+.PHONY: all clean force

--- a/deps/poulet4/Makefile
+++ b/deps/poulet4/Makefile
@@ -4,6 +4,7 @@
 
 all: Makefile.coq
 	@+$(MAKE) -f Makefile.coq all
+	$(MAKE) -C extraction
 
 clean: Makefile.coq
 	@+$(MAKE) -f Makefile.coq cleanall

--- a/deps/poulet4/_CoqProject
+++ b/deps/poulet4/_CoqProject
@@ -1,0 +1,17 @@
+-R lib Petr4
+
+lib/Monads/Monad.v
+lib/Monads/Option.v
+lib/Monads/State.v
+lib/Utils.v
+lib/Value.v
+lib/Step.v
+lib/Environment.v
+lib/Unpack.v
+lib/Eval.v
+lib/Syntax.v
+lib/Platform/Packet.v
+
+-R extraction Petr4
+
+extraction/Extract.v

--- a/deps/poulet4/extraction/Extract.v
+++ b/deps/poulet4/extraction/Extract.v
@@ -1,0 +1,7 @@
+Require Syntax.
+Require Extraction.
+
+Cd "extraction/lib/".
+Extraction Language OCaml.
+Separate Extraction Syntax.
+Cd "../../".

--- a/deps/poulet4/extraction/Makefile
+++ b/deps/poulet4/extraction/Makefile
@@ -1,0 +1,18 @@
+# Copyright 2019-present Cornell University
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+.PHONY: all
+
+all:
+	opam install .

--- a/deps/poulet4/extraction/dune-project
+++ b/deps/poulet4/extraction/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.2)
+(name poulet4)

--- a/deps/poulet4/extraction/lib/dune
+++ b/deps/poulet4/extraction/lib/dune
@@ -1,0 +1,4 @@
+(library 
+  (name poulet4)
+  (public_name poulet4)
+)

--- a/deps/poulet4/extraction/poulet4.opam
+++ b/deps/poulet4/extraction/poulet4.opam
@@ -1,0 +1,13 @@
+opam-version: "2.0"
+version: "0.1.0"
+synopsis: "Poulet4: Petr4 in Coq (extracted ML code)"
+maintainer: "jnfoster@cs.cornell.edu"
+authors: ["Nate Foster <jnfoster@cs.cornell.edu>"]
+homepage: "https://github.com/cornell-netlab/poulet4"
+dev-repo: "git+https://github.com/cornell-netlab/poulet4/"
+bug-reports: "https://github.com/cornell-netlab/poulet4/issues"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+]

--- a/deps/poulet4/lib/Environment.v
+++ b/deps/poulet4/lib/Environment.v
@@ -1,0 +1,150 @@
+Require Import Coq.Strings.String.
+Require Import Coq.Lists.List.
+Require Import Coq.FSets.FMapList.
+Require Import Coq.Structures.OrderedTypeEx.
+
+Require Import Monads.Monad.
+Require Import Monads.Option.
+Require Import Monads.State.
+
+Require Import Value.
+
+Open Scope string_scope.
+Open Scope monad.
+
+Module Import MStr := FMapList.Make(String_as_OT).
+
+Inductive exception :=
+| PacketTooShort
+| Reject
+| Exit
+| Internal.
+
+Definition scope := MStr.t value.
+Definition environment := list scope.
+
+Definition env_monad := @state_monad environment exception.
+
+Definition map_env (f : environment -> environment) : env_monad unit :=
+  fun env => mret tt (f env).
+
+Definition lift_env_fn (f : environment -> option environment) : env_monad unit :=
+  fun env =>
+    match f env with
+    | Some env' => mret tt env'
+    | None => state_fail Internal env
+    end.
+
+Definition lift_env_lookup_fn (f: environment -> option value) : env_monad value :=
+  fun env =>
+    match f env with
+    | Some res => mret res env
+    | None => state_fail Internal env
+    end.
+
+Definition lift_option {A : Type} (x: option A) : env_monad A := fun env => 
+  match x with
+  | Some it => mret it env
+  | None => (inr Internal, env)
+  end.
+
+Definition update_scope (key: string) (val: value) (bindings: scope) : option scope :=
+  MStr.find key bindings;;
+  mret (MStr.add key val (MStr.remove key bindings)).
+
+Definition insert_scope (key: string) (val: value) (bindings: scope) : option scope :=
+  MStr.find key bindings;;
+  mret (MStr.add key val bindings).
+
+Definition find_scope (key: string) (bindings: scope) : option value :=
+  MStr.find key bindings.
+
+Definition push_scope (env: environment) :=
+  MStr.empty _ :: env.
+
+Definition pop_scope (env: environment) : option environment :=
+  match env with
+  | _ :: rest => Some rest
+  | nil => None
+  end.
+
+Fixpoint update_environment' (key: string) (val: value) (env: environment) : option environment :=
+  match env with
+  | inner :: rest =>
+    if MStr.find key inner
+    then let* inner' := update_scope key val inner in
+         mret (inner' :: rest)
+    else let* rest' := update_environment' key val rest in
+         mret (inner :: rest')
+  | nil => None
+  end.
+
+Definition update_environment (key: string) (val: value) : env_monad unit :=
+  lift_env_fn (update_environment' key val).
+
+Definition insert_environment' (key: string) (val: value) (env: environment) : option environment :=
+  match env with
+  | inner :: rest =>
+    let* inner' := insert_scope key val inner in
+    mret (inner' :: rest)
+  | nil => None
+  end.
+
+Definition insert_environment (key: string) (val: value) : env_monad unit :=
+  lift_env_fn (insert_environment' key val).
+  
+Fixpoint find_environment' (key: string) (env: environment) : option value :=
+  match env with
+  | inner :: rest =>
+    match MStr.find key inner with
+    | Some v => Some v
+    | None => find_environment' key rest
+    end
+  | nil => None
+  end.
+
+Definition find_environment (key: string) : env_monad value :=
+  lift_env_lookup_fn (find_environment' key).
+
+Fixpoint find_lvalue' (lval: lvalue) (env: environment) : option value :=
+  match lval with
+  | LValName var =>
+    find_environment' var env
+  | LValMember lval' member =>
+    let* val := find_lvalue' lval' env in
+    match val with
+    | ValRecord map =>
+      Raw.find member map
+    | _ => None
+    end
+  end.
+
+Definition find_lvalue (lval: lvalue) : env_monad value :=
+  lift_env_lookup_fn (find_lvalue' lval).
+
+Fixpoint update_lvalue' (lval: lvalue) (val: value) (env: environment) : option environment :=
+  match lval with
+  | LValName var =>
+    update_environment' var val env
+  | LValMember lval' member =>
+    let* obj := find_lvalue' lval' env in
+    let* obj' := update_member obj member val in
+    update_lvalue' lval' obj' env
+  end.
+
+Definition update_lvalue (lval: lvalue) (val: value) : env_monad unit :=
+  lift_env_fn (update_lvalue' lval val).
+
+Definition toss_value (original: env_monad value) : env_monad unit :=
+  fun env =>
+    match original env with
+    | (inl result, env') => mret tt env'
+    | (inr exc, env') => state_fail exc env'
+    end.
+
+Definition dummy_value (original: env_monad unit) : env_monad value :=
+  fun env =>
+    match original env with
+    | (inl tt, env') => mret ValVoid env'
+    | (inr exc, env') => state_fail exc env'
+    end.

--- a/deps/poulet4/lib/Eval.v
+++ b/deps/poulet4/lib/Eval.v
@@ -1,0 +1,220 @@
+Require Import Coq.Bool.Bvector.
+Require Import Coq.Lists.List.
+Require Import Coq.NArith.BinNatDef.
+Require Import Coq.ZArith.BinIntDef.
+Require Import Coq.Strings.String.
+
+Require Import Monads.Monad.
+Require Import Monads.Option.
+Require Import Monads.State.
+
+Require Import Value.
+Require Import Environment.
+Require Import Syntax.
+Require Import Utils.
+Require Import Unpack.
+
+Require Import Platform.Packet.
+
+
+Open Scope monad.
+
+Definition default_value (A: type) : value.
+Admitted.
+
+Definition eval_lvalue (expr: expression) : env_monad lvalue.
+Admitted.
+
+Definition eval_minus (v: value) : option value := 
+  match v with
+  | ValFixedBit width bits => Some (ValFixedInt width (Z.sub (pow_two width) (of_bvector bits)))
+  | ValFixedInt width value => Some (ValFixedInt width (Z.sub (pow_two width) value))
+  | ValInfInt n => Some (ValInfInt (Z.opp n))
+  | _ => None
+  end.
+
+Fixpoint eval_expression (expr: expression) : env_monad value :=
+  match expr with
+  | BoolExpression value => mret (ValBool value)
+  | IntExpression value => mret (ValInfInt value)
+  | StringExpression value => mret (ValString value)
+  | ArrayAccess array index =>
+    let* index' := unpack_inf_int (eval_expression index) in
+    let* array' := unpack_array (eval_expression array) in
+    lift_option (index_z_error array' index')
+  | BitStringAccess array hi lo =>
+    let* array' := unpack_array (eval_expression array) in
+    let* hi'    := unpack_inf_int (eval_expression hi) in
+    let* lo'    := unpack_inf_int (eval_expression lo) in
+    lift_option (option_map ValArray (list_slice_z array' lo' hi'))
+  | List exprs =>
+    lift_monad ValArray (sequence (List.map eval_expression exprs))
+  | Record entries => 
+    let actions := List.map (fun x => match x with | MkKeyValue k e => v <- eval_expression e ;; mret (k, v) end) entries in
+    lift_monad ValRecord (sequence actions)
+  | UnaryOp op arg => 
+    match op with
+    | Not => 
+      let* b := unpack_bool (eval_expression arg) in
+      mret (ValBool (negb b))
+    | BitNot => 
+      let* inner := eval_expression arg in
+      match inner with
+      | ValFixedBit w bits => mret (ValFixedBit w (Bneg w bits))
+      | ValVarBit w bits => mret (ValVarBit w (Bneg w bits))
+      | _ => state_fail Internal
+      end
+    | BitMinus =>
+      let* inner := eval_expression arg in
+      lift_option (eval_minus inner)
+    end
+  | _ => mret (ValBool false) (* TODO *)
+  end.
+
+Definition eval_is_valid (obj: lvalue) : env_monad value :=
+  let* MkHeader valid _ := unpack_header (find_lvalue obj) in
+  mret (ValBool valid).
+
+Definition eval_set_bool (obj: lvalue) (valid: bool) : env_monad unit :=
+  let* MkHeader _ fields := unpack_header (find_lvalue obj) in
+  update_lvalue obj (ValHeader (MkHeader valid fields)).
+
+Definition eval_pop_front (obj: lvalue) (args: list (option value)) : env_monad unit :=
+  match args with
+  | Some (ValInfInt count) :: nil => 
+      let* '(size, next_index, elements) := unpack_header_stack (find_lvalue obj) in
+      let padding := MkHeader false (MStr.Raw.empty _) in
+      let* elements' := lift_option (rotate_left_z elements count padding) in
+      let next_index' := next_index - (Z.to_nat count) in
+      let value' := ValHeaderStack size next_index' elements' in
+      update_lvalue obj value'
+  | _ => state_fail Internal
+  end.
+
+Definition eval_push_front (obj: lvalue) (args: list (option value)) : env_monad unit :=
+  match args with
+  | Some (ValInfInt count) :: nil => 
+      let* '(size, next_index, elements) := unpack_header_stack (find_lvalue obj) in
+      let padding := MkHeader false (MStr.Raw.empty _) in
+      let* elements' := lift_option (rotate_right_z elements count padding) in
+      let next_index' := min size (next_index + (Z.to_nat count)) in
+      let value' := ValHeaderStack size next_index' elements' in
+      update_lvalue obj value'
+  | _ => state_fail Internal
+  end.
+
+Fixpoint eval_arguments (args: list (option expression)) : env_monad (list (option value)) :=
+  match args with
+  | nil => mret nil
+  | Some arg :: args' =>
+    let* val := eval_expression arg in
+    let* vals := eval_arguments args' in
+    mret (Some val :: vals)
+  | None :: args' =>
+    let* vals := eval_arguments args' in
+    mret (None :: vals)
+  end.
+
+Definition eval_builtin_func (name: string) (obj: lvalue) (args: list (option expression)) : env_monad value :=
+  let* args' := eval_arguments args in
+  match name with
+  | "isValid" => eval_is_valid obj
+  | "setValid" => dummy_value (eval_set_bool obj true)
+  | "setInvalid" => dummy_value (eval_set_bool obj false)
+  | "pop_front" => dummy_value (eval_pop_front obj args')
+  | "push_front" => dummy_value (eval_push_front obj args')
+  | _ => state_fail Internal
+  end.
+
+Definition eval_packet_func (obj: lvalue) (name: string) (bits: list bool) (type_args: list type) (args: list (option expression)) : env_monad unit :=
+  match name with
+  | "extract" =>
+    match (args, type_args) with
+    | ((Some target_expr) :: nil, into :: nil) =>
+      let* target := eval_lvalue target_expr in
+      match eval_packet_extract_fixed into bits with
+      | (inr error, bits') =>
+        update_lvalue obj (ValExternObj (Packet bits')) ;;
+        state_fail error
+      | (inl value, bits') =>
+        update_lvalue obj (ValExternObj (Packet bits')) ;;
+        update_lvalue target value ;;
+        mret tt
+      end
+    | _ => state_fail Internal
+    end
+  | _ => state_fail Internal
+  end.
+
+Definition eval_extern_func (name: string) (obj: lvalue) (type_args: list type) (args: list (option expression)): env_monad value :=
+  let* Packet bits := unpack_extern_obj (find_lvalue obj) in
+  dummy_value (eval_packet_func obj name bits type_args args).
+
+Definition eval_method_call (func: expression) (type_args: list type) (args: list (option expression)) : env_monad value :=
+  let* func' := eval_expression func in
+  match func' with
+  | ValBuiltinFunc name obj => eval_builtin_func name obj args
+  | ValExternFunc name obj => eval_extern_func name obj type_args args
+  | _ => state_fail Internal (* TODO: other function types *)
+  end.
+
+Fixpoint eval_block (blk: block) : env_monad unit :=
+  match blk with
+  | BlockCons stmt rest =>
+    eval_statement stmt;;
+    eval_block rest
+  | BlockEmpty => mret tt
+  end
+
+with eval_statement (stmt: statement) : env_monad unit :=
+  match stmt with
+  | MethodCall func type_args args =>
+    toss_value (eval_method_call func type_args args)
+  | Assignment lhs rhs =>
+    let* lval := eval_lvalue lhs in
+    let* val := eval_expression rhs in
+    update_lvalue lval val
+  | BlockStatement block =>
+    map_env push_scope;;
+    eval_block block;;
+    lift_env_fn pop_scope
+  | StatementConstant type name init =>
+    let* value := eval_expression init in
+    insert_environment name value
+  | StatementVariable type name init =>
+    let* value :=
+       match init with
+       | None => mret (default_value type)
+       | Some expr => eval_expression expr
+       end
+    in
+    insert_environment name value
+  end.
+
+  (* TODO: sophisticated pattern matching for the match expression as needed *)
+Fixpoint eval_match_expression (vals: list value) (matches: list match_expression) : env_monad bool :=
+  match (vals, matches) with
+  | (List.nil, List.nil) => mret true
+  | (v :: vals', m :: matches') => 
+    match m with
+    | DontCare          => eval_match_expression vals' matches'
+    | MatchExpression e => 
+      let* v' := eval_expression e in 
+        if eq_value v v' then eval_match_expression vals' matches' else mret false
+    end
+  | _ => mret false
+  end.
+
+Fixpoint eval_cases (vals: list value) (cases: list Case.case) : env_monad string := 
+  match cases with
+  | List.nil    => state_fail Internal
+  | c :: cases' => 
+    let* passes := eval_match_expression vals (Case.matches c) in
+      if passes then mret (Case.next c) else eval_cases vals cases'
+  end.
+
+
+Definition eval_transition (t: Transition.transition) : env_monad string := 
+  let* vs := sequence (List.map eval_expression (Transition.exprs t)) in 
+    eval_cases vs (Transition.cases t).
+

--- a/deps/poulet4/lib/Monads/Monad.v
+++ b/deps/poulet4/lib/Monads/Monad.v
@@ -1,0 +1,43 @@
+Require Import Coq.Lists.List.
+
+Class Monad (M : Type -> Type) : Type :=
+  { mret : forall {A}, A -> M A;
+    mbind : forall {A B}, M A -> (A -> M B) -> M B
+  }.
+
+(* Adapted from coq-ext-lib *)
+(* https://github.com/coq-community/coq-ext-lib/blob/v8.5/theories/Structures/Monad.v*)
+
+Declare Scope monad_scope.
+Delimit Scope monad_scope with monad.
+
+Notation "c >>= f" := (@mbind _ _ _ _ c f) (at level 50, left associativity) : monad_scope.
+Notation "f =<< c" := (@mbind _ _ _ _ c f) (at level 51, right associativity) : monad_scope.
+
+Notation "x <- c1 ;; c2" := (@mbind _ _ _ _ c1 (fun x => c2))
+  (at level 100, c1 at next level, right associativity) : monad_scope.
+
+Notation "e1 ;; e2" := (_ <- e1%monad ;; e2%monad)%monad
+  (at level 100, right associativity) : monad_scope.
+
+Notation "'let*' x ':=' c1 'in' c2" := (@mbind _ _ _ _ c1 (fun x => c2))
+  (at level 61, x pattern, format "'let*' x ':=' c1 'in' c2", c1 at next level, right associativity) : monad_scope.
+
+Notation "'let*' ' x ':=' c1 'in' c2" := (@mbind _ _ _ _ c1 (fun x => c2))
+  (at level 61, x pattern, format "'let*' ' x ':=' c1 'in' c2", c1 at next level, right associativity) : monad_scope.
+
+Open Scope monad.
+
+
+
+Fixpoint sequence {A} {m: Type -> Type} {M : Monad m} (acts: list (m A)) : m (list A) := 
+  match acts with
+  | nil => mret nil
+  | x :: xs => 
+    let* t    := x in
+    let* rest := @sequence A m M xs in 
+      mret (t :: rest)
+  end.
+
+Definition lift_monad {A B} {m: Type -> Type} {M : Monad m} (f: A -> B) (ma : m A) : m B :=
+  ma >>= fun a => mret (f a).

--- a/deps/poulet4/lib/Monads/Option.v
+++ b/deps/poulet4/lib/Monads/Option.v
@@ -1,0 +1,16 @@
+Require Import Monads.Monad.
+
+Open Scope monad.
+
+Definition option_ret (A: Type) (a: A) := Some a.
+
+Definition option_bind (A B: Type) (c: option A) (f: A -> option B) : option B :=
+  match c with
+  | Some a => f a
+  | None => None
+  end.
+
+Global Instance option_monad_inst : Monad option :=
+  { mret := option_ret;
+    mbind := option_bind;
+  }.

--- a/deps/poulet4/lib/Monads/State.v
+++ b/deps/poulet4/lib/Monads/State.v
@@ -1,0 +1,30 @@
+Require Import Monads.Monad.
+
+Open Scope monad.
+
+
+Definition state_monad {State Exception Result: Type} :=
+  State -> (Result + Exception) * State.
+
+Definition state_return {State Exception Result: Type} (res: Result) : @state_monad State Exception Result :=
+  fun env => (inl res, env).
+  
+Definition state_fail {State Exception Result: Type} (exc: Exception) : @state_monad State Exception Result :=
+  fun env => (inr exc, env).
+
+Definition state_bind
+  {State Exception Result Result': Type}
+  (c: @state_monad State Exception Result)
+  (f: Result -> @state_monad State Exception Result') 
+  : @state_monad State Exception Result' :=
+  fun env =>
+    let (ret, env') := c env in
+    match ret with 
+    | inl result => f result env'
+    | inr exc => (inr exc, env')
+    end.
+    
+Global Instance state_monad_inst {State Exception: Type} : Monad (@state_monad State Exception) :=
+  { mret := @state_return State Exception;
+    mbind := @state_bind State Exception
+  }.

--- a/deps/poulet4/lib/Platform/Packet.v
+++ b/deps/poulet4/lib/Platform/Packet.v
@@ -1,0 +1,60 @@
+Require Import Coq.Bool.Bvector.
+Require Import Coq.Lists.List.
+Require Import Coq.Strings.String.
+Require Import Coq.ZArith.BinIntDef.
+
+Require Import Monads.Monad.
+Require Import Monads.State.
+
+Require Import Environment.
+Require Import Value.
+Require Import Utils.
+Require Import Syntax.
+
+Open Scope monad.
+
+Definition packet_monad := @state_monad (list bool) exception.
+
+Fixpoint read_first_bits (count: nat) : packet_monad (Bvector count) :=
+  match count with
+  | 0 => mret []%vector
+  | S count' =>
+    fun bits =>
+      match bits with
+      | nil => state_fail PacketTooShort bits
+      | bit :: bits' =>
+        match read_first_bits count' bits' with
+        | (inr error, bits'') => state_fail error bits''
+        | (inl rest, bits'') => state_return (bit :: rest)%vector bits''
+        end
+      end
+  end.
+
+Fixpoint eval_packet_extract_fixed (into: type) : packet_monad value :=
+  match into with
+  | Bool =>
+    let* vec := read_first_bits 1 in
+    match vec with
+    | (bit :: [])%vector => mret (ValBool bit)
+    | _ => state_fail Internal
+    end
+  | Bit width =>
+    let* vec := read_first_bits width in
+    mret (ValFixedBit width vec)
+  | Int width =>
+    let* vec := read_first_bits width in
+    match vec with
+    | (false :: rest)%vector => mret (ValFixedInt width (of_bvector rest))
+    | (true :: rest)%vector =>
+      let negated := Z.sub (pow_two width) (of_bvector rest) in
+      mret (ValFixedInt width negated)
+    | _ => state_fail Internal
+    end
+  | RecordType fs =>
+    let* fs' := sequence (List.map (fun '(n, t) => v <- eval_packet_extract_fixed t ;; mret (n, v)) fs) in
+    mret (ValRecord fs')
+  | Header fs =>
+    let* fs' := sequence (List.map (fun '(n, t) => v <- eval_packet_extract_fixed t ;; mret (n, v)) fs) in
+    mret (ValHeader (MkHeader true fs'))
+  | _ => state_fail Internal
+  end.

--- a/deps/poulet4/lib/Step.v
+++ b/deps/poulet4/lib/Step.v
@@ -1,0 +1,45 @@
+Require Import Syntax.
+Require Import Eval.
+Require Import Environment.
+Require Import Monads.Monad.
+Require Import Monads.State.
+Require Import Coq.Strings.String.
+Require Import Coq.Lists.List.
+
+Open Scope monad.
+(* Open Scope list_scope. *)
+
+(* Open Scope string_scope. *)
+
+Definition states_to_block (ss: list statement) : block := List.fold_right BlockCons BlockEmpty ss.
+
+Fixpoint lookup_state (states: list State.state) (name: string) : option State.state := 
+  match states with
+  | List.nil => None
+  | s :: states' => if String.eqb name (State.name s) then Some s else lookup_state states' name
+  end.
+
+
+Definition step (p: Parser.parser) (start: string) : env_monad string := 
+  match lookup_state (Parser.states p) start with
+  | Some nxt => 
+    let* _ := eval_statement (BlockStatement (states_to_block (State.statements nxt))) in
+      eval_transition (State.transition nxt)
+  | None     => state_fail Internal
+  end.
+
+(* TODO: formalize progress with respect to a header, such that if the parser 
+  always makes forward progress then there exists a fuel value for which
+  the parser either rejects or accepts (or errors, but not due to lack of fuel) 
+*)
+Fixpoint step_trans (p: Parser.parser) (fuel: nat) (start: string) : env_monad unit := 
+  match fuel with 
+  | 0   => state_fail Internal (* TODO: add a separate exception for out of fuel? *)
+  | S x => let* state' := step p start in 
+    match state' with
+    | "accept"    => mret tt
+    | "reject"    => state_fail Reject
+    | name    => step_trans p x name
+    end
+  end. 
+  

--- a/deps/poulet4/lib/Syntax.v
+++ b/deps/poulet4/lib/Syntax.v
@@ -1,0 +1,191 @@
+Require Import Coq.Strings.String.
+Require Import Coq.Lists.List.
+
+Require Import Monads.Monad.
+Require Import Monads.Option.
+Require Import Monads.State.
+
+Require Import Utils.
+Require Import Environment.
+Require Import Value.
+Require Import Coq.Numbers.BinNums.
+
+Open Scope monad.
+
+Inductive direction :=
+  | In
+  | Out
+  | InOut
+  | Directionless.
+
+Inductive function_kind := 
+  | Parser
+  | Control
+  | Extern
+  | Table
+  | Action
+  | Function
+  | Builtin
+.
+
+Inductive name :=
+  | BareName (nm: string)
+  | QualifiedName (path: list string) (nm: string)
+.
+
+Inductive unaryoperator :=
+  | Not
+  | BitNot
+  | BitMinus
+.
+
+Inductive binaryoperator :=
+  | Plus
+  | PlusSat
+  | Minus
+  | MinusSat
+  | Mul
+  | Div
+  | Mod
+  | Shl
+  | Shr
+  | Le
+  | Ge
+  | Lt
+  | Gt
+  | Eq
+  | NotEq
+  | BitAnd
+  | BitXor
+  | BitOr
+  | PlusPlus
+  | And
+  | Or
+.
+
+Inductive type := 
+  | Bool
+  | String
+  | Integer
+  | Int (width: nat)
+  | Bit (width: nat)
+  | VarBit (width: nat)
+  | Array (inner: type) (size: nat)
+  | Tuple (types: list type)
+  | RecordType (fields: list (string * type))
+  | SetType (inner: type)
+  | Error
+  | MatchKind
+  | TypeName (name: string)
+  | NewType (inner: type)
+  | Void
+  | Header (fields: list (string * type))
+  | HeaderUnion (fields: list (string * type))
+  | Struct (fields: list (string * type))
+  | Enum (name: string) (members: list string) (inner: option type)
+  | SpecializedType (base: type) (args: list type)
+  | ExternType (name: string) (type_params: list string) (methods: list (string * function))
+  | FunctionType (inner: function) 
+  | ActionType (data_params: list param) (control_params: list param)
+  | Constructor (type_params: list string) (params: list param) (return_type: type)
+
+with function := MkFunction 
+  (type_params: list string)
+  (parameters: list param)
+  (kind: function_kind)
+  (return_type: type)
+
+with param := MkParam
+  (dir: direction)
+  (typ: type)
+  (variable: string)
+  (opt_value: option expression)
+  
+with keyvalue := MkKeyValue
+  (key: string)
+  (expr: expression)
+
+with argument :=
+  | Expression (value: expression)
+  | KeyValue (key: string) (value: expression)
+  | Missing
+
+with expression := 
+  | BoolExpression (value : bool)
+  | IntExpression (value: Z)
+  | StringExpression (value: string)
+  | NameExpression (value: name)
+  | ArrayAccess (array: expression) (index: expression)
+  | BitStringAccess (array: expression) (hi: expression) (lo: expression)
+  | List (values: list expression)
+  | Record (entries: list keyvalue)
+  | UnaryOp (op: unaryoperator) (arg: expression)
+  | BinaryOp (op: binaryoperator) (arg: expression)
+  | Cast (type: type) (expr: expression)
+  | TypeMember (type: name) (name: string)
+  | ErrorMember (error: string)
+  | ExpressionMember (expr: expression) (name: string)
+  | Ternary (cond: expression) (true: expression) (false: expression)
+  | FunctionCall (function: expression) (type_args: list type) (args: list argument)
+  | NamelessInstantiation (type: type) (args: list argument)
+  | Mask (expr: expression) (mask: expression)
+  | Range (lo: expression) (hi: expression)
+.
+
+Inductive declaration :=
+  | DeclarationConstant (type: type) (name: string) (value: expression)
+  | DeclarationVariable (type: type) (name: string) (init: option expression)
+  | Instantiation (type: type) (args: list expression) (name: string)
+.
+
+Inductive statement := 
+  | MethodCall (func: expression) (type_args: list type) (args: list (option expression))
+  | Assignment (lhs: expression) (rhs: expression)
+  | BlockStatement (blk: block)
+  (* same as the corresponding cases of declaration *)
+  | StatementConstant (type: type) (name: string) (value: expression)
+  | StatementVariable (type: type) (name: string) (init: option expression)
+
+with block :=
+  | BlockEmpty : block
+  | BlockCons : statement -> block -> block
+.
+
+Inductive match_expression := 
+  | DontCare
+  | MatchExpression (expr: expression)
+.
+
+Module Case.
+Record case := { 
+  matches: list match_expression;
+  next: string 
+}.
+End Case.
+
+Module Transition.
+Record transition := { 
+  exprs: list expression;
+  cases: list Case.case 
+}.
+End Transition.
+
+Module State.
+Record state := { 
+  name: string;
+  statements: list statement;
+  transition: Transition.transition
+}.
+End State.
+
+
+Module Parser.
+Record parser := MkParser { 
+  parser_name: string;
+  (*type_params: list string;*)
+  params: list param;
+  constructor_params: list param;
+  locals: list declaration;
+  states: list State.state 
+}.
+End Parser.

--- a/deps/poulet4/lib/Unpack.v
+++ b/deps/poulet4/lib/Unpack.v
@@ -1,0 +1,95 @@
+Require Import Coq.NArith.BinNatDef.
+Require Import Coq.ZArith.BinIntDef.
+Require Import Coq.Strings.String.
+
+Require Import Monads.Monad.
+Require Import Monads.State.
+
+Require Import Value.
+Require Import Environment.
+
+Definition unpack_bool (wrapped: env_monad value) : env_monad bool :=
+  let* unwrapped := wrapped in
+  match unwrapped with
+  | ValBool b => mret b
+  | _ => state_fail Internal
+  end.
+
+(* TODO: unpack_fixed_bit, unpack_var_bit; dependent types make things hard here *)
+
+Definition unpack_fixed_int (wrapped: env_monad value) : env_monad (nat * Z) :=
+  let* unwrapped := wrapped in
+  match unwrapped with
+  | ValFixedInt w n => mret (w, n)
+  | _ => state_fail Internal
+  end.
+
+Definition unpack_inf_int (wrapped: env_monad value) : env_monad Z :=
+  let* unwrapped := wrapped in
+  match unwrapped with
+  | ValInfInt n => mret n
+  | _ => state_fail Internal
+  end.
+
+Definition unpack_string (wrapped: env_monad value) : env_monad string :=
+  let* unwrapped := wrapped in
+  match unwrapped with
+  | ValString s => mret s
+  | _ => state_fail Internal
+  end.
+
+Definition unpack_array (wrapped: env_monad value) : env_monad (list value) :=
+  let* unwrapped := wrapped in
+  match unwrapped with
+  | ValArray a => mret a
+  | _ => state_fail Internal
+  end.
+
+Definition unpack_error (wrapped: env_monad value) : env_monad string :=
+  let* unwrapped := wrapped in
+  match unwrapped with
+  | ValError e => mret e
+  | _ => state_fail Internal
+  end.
+
+Definition unpack_record (wrapped: env_monad value) : env_monad (MStr.Raw.t value) :=
+  let* unwrapped := wrapped in
+  match unwrapped with
+  | ValRecord fs => mret fs
+  | _ => state_fail Internal
+  end.
+
+Definition unpack_builtin_func (wrapped: env_monad value) : env_monad (string * lvalue) :=
+  let* unwrapped := wrapped in
+  match unwrapped with
+  | ValBuiltinFunc name obj => mret (name, obj)
+  | _ => state_fail Internal
+  end.
+
+Definition unpack_extern_func (wrapped: env_monad value) : env_monad (string * lvalue) :=
+  let* unwrapped := wrapped in
+  match unwrapped with
+  | ValExternFunc name obj => mret (name, obj)
+  | _ => state_fail Internal
+  end.
+
+Definition unpack_extern_obj (wrapped: env_monad value) : env_monad extern :=
+  let* unwrapped := wrapped in
+  match unwrapped with
+  | ValExternObj e => mret e
+  | _ => state_fail Internal
+  end.
+
+Definition unpack_header (wrapped: env_monad value) : env_monad header :=
+  let* unwrapped := wrapped in
+  match unwrapped with
+  | ValHeader h => mret h
+  | _ => state_fail Internal
+  end.
+
+Definition unpack_header_stack (wrapped: env_monad value) : env_monad (nat * nat * (list header)) :=
+  let* unwrapped := wrapped in
+  match unwrapped with
+  | ValHeaderStack s n hdrs => mret (s, n, hdrs)
+  | _ => state_fail Internal
+  end.

--- a/deps/poulet4/lib/Utils.v
+++ b/deps/poulet4/lib/Utils.v
@@ -1,0 +1,96 @@
+Require Import Coq.Bool.Bvector.
+Require Import Coq.Lists.List.
+Require Import Coq.Strings.String.
+Require Import Coq.NArith.BinNatDef.
+Require Import Coq.ZArith.BinIntDef.
+Require Import Coq.PArith.BinPos.
+Require Import Coq.Structures.OrderedTypeEx.
+
+Require Import Monads.Monad.
+Require Import Monads.Option.
+
+Open Scope monad.
+
+Fixpoint assoc_update {A: Type} (key: string) (val: A) (map: list (string * A)) : option (list (string * A)) :=
+  match map with
+  | (s, v) :: map' =>
+    if String_as_OT.eq_dec s key
+    then mret ((key, val) :: map')
+    else let* map' := assoc_update key val map' in
+         mret ((s, v) :: map')
+  | nil => None
+  end.
+
+Fixpoint rotate_left_nat {A: Type} (elements: list A) (count: nat) (pad: A) : option (list A) :=
+  match count with
+  | 0 => Some elements
+  | S count' =>
+    match elements with
+    | nil => None
+    | header :: elements' =>
+      rotate_left_nat (elements' ++ pad :: nil) count' pad
+    end
+  end.
+
+Definition rotate_left_z {A: Type} (elements: list A) (count: Z) (pad: A) : option (list A) :=
+  match count with 
+  | Zneg _ => None
+  | Zpos count' => rotate_left_nat elements (Pos.to_nat count') pad
+  | Z0 => rotate_left_nat elements 0 pad
+  end.
+
+  
+Fixpoint rotate_right_nat {A: Type} (elements: list A) (count: nat) (pad: A) : option (list A) :=
+  match count with
+  | 0 => Some elements
+  | S count' =>
+    match elements  with
+    | nil => None
+    | header :: elements' =>
+      rotate_right_nat (pad :: (removelast elements)) count' pad
+    end
+  end.
+
+Definition rotate_right_z {A: Type} (elements: list A) (count: Z) (pad: A) : option (list A) :=
+  match count with 
+  | Zneg _ => None
+  | Zpos count' => rotate_right_nat elements (Pos.to_nat count') pad
+  | Z0 => rotate_right_nat elements 0 pad
+  end.
+
+Definition list_slice_z {A: Type} (l: list A) (lo: Z) (hi: Z) : option (list A).
+Admitted.
+
+Fixpoint list_slice_nat {A: Type} (l: list A) (lo: nat) (hi: nat) : option (list A) := 
+  match (lo, hi) with
+  | (0, 0)          => Some nil
+  | (S _, 0)        => None
+  | (0, S hi')      =>
+    match l with
+    | nil     => None
+    | x :: xs => option_map (fun t => x :: t) (list_slice_nat xs 0 hi')
+    end
+  | (S lo', S hi')  =>
+    match l with
+    | nil      => None
+    | x :: xs => option_map (fun t => x :: t) (list_slice_nat xs lo' hi')
+    end
+  end.
+
+Definition index_z_error {A} (xs: list A) (i: Z) : option A.
+Admitted.
+
+Fixpoint pow_two (w: nat) : Z :=
+  match w with
+  | 0     => 1
+  | S w'  => Z.double (pow_two w')
+  end.
+
+(* Coq Bvectors are little-endian *)
+Open Scope vector_scope.
+Fixpoint of_bvector {w} (bits: Bvector w) : Z :=
+  match bits with
+  | [] => 0
+  | (b :: bits') => Z.add (if b then 1 else 0) (Z.double (of_bvector bits'))
+  end.
+Close Scope vector_scope.

--- a/deps/poulet4/lib/Value.v
+++ b/deps/poulet4/lib/Value.v
@@ -1,0 +1,85 @@
+Require Import Coq.Strings.String.
+Require Import Coq.FSets.FMapList.
+Require Import Coq.Structures.OrderedTypeEx.
+Require Import Coq.Bool.Bvector.
+Require Import Coq.Numbers.BinNums.
+Require Import Coq.ZArith.BinIntDef.
+Require Coq.Strings.String.
+
+Require Import Monads.Monad.
+Require Import Monads.Option.
+
+Require Import Utils.
+
+Module Import MStr := FMapList.Make(String_as_OT).
+
+Open Scope monad.
+
+Inductive lvalue :=
+  | LValName (var: string)
+  | LValMember (base: lvalue) (member: string)
+.
+
+Inductive extern :=
+  | Packet (bits: list bool)
+.
+
+Inductive value :=
+| ValVoid
+| ValBool (b: bool)
+| ValFixedBit (width: nat) (value: Bvector width)
+| ValVarBit (width: nat) (value: Bvector width)
+| ValFixedInt (width: nat) (n: Z)
+| ValInfInt (n: Z)
+| ValString (s: string)
+| ValArray (arr: list value)
+| ValError (msg: string)
+(* I would rather this was MStr.t value but that is not a strictly
+positive definition. The difference is that [Raw.t value] is
+basically list (string * value) while MStr.t value is a dependent
+record { raw: MStr.Raw.t; sorted: Sorted ...} which includes a proof
+that the list [raw] is sorted. *)
+| ValRecord (fs: MStr.Raw.t value)
+| ValBuiltinFunc (name: string) (obj: lvalue)
+| ValExternFunc (name: string) (obj: lvalue)
+| ValExternObj (ext: extern)
+| ValHeader (value: header)
+| ValHeaderStack (size: nat) (nextIndex: nat) (elements: list header)
+
+(* unused value types from the OCAML implementation
+
+  | VStruct of
+      { fields : (string * value) list; }
+  | VUnion of
+      { fields : (string * value) list; }
+  | VEnumField of
+      { typ_name : string;
+        enum_name : string; }
+  | VSenumField of
+      { typ_name : string;
+        enum_name : string;
+        v : value; }
+  | VSenum of (string * value) list *)
+
+with header := MkHeader (valid: bool) (fields: MStr.Raw.t value).
+Open Scope nat_scope.
+(* TODO: wrap this in a module and call it eqb, and prove that l `eqb` r => l = r *)
+Fixpoint eq_value (l: value) (r: value) : bool :=
+  match (l, r) with
+  | (ValVoid, ValVoid) => true
+  | (ValBool b_l, ValBool b_r) => eqb b_l b_r
+  | (ValFixedBit w_l v_l, ValFixedBit w_r v_r) => (Nat.eqb w_l w_r) && (BVeq _ _ v_l v_r)
+  | (ValVarBit w_l v_l, ValVarBit w_r v_r) => (Nat.eqb w_l w_r) && (BVeq _ _ v_l v_r)
+  | (ValFixedInt w_l v_l, ValFixedInt w_r v_r) => (Nat.eqb w_l w_r) && (Z.eqb v_l v_r)
+  | (ValInfInt v_l, ValInfInt v_r) => Z.eqb v_l v_r
+  | (ValString v_l, ValString v_r) => String.eqb v_l v_r
+  | _ => false (* TODO: arrays, errors, records, funcs, headers, headerstacks*)
+  end.
+
+Definition update_member (obj: value) (member: string) (val: value) : option value :=
+  match obj with
+  | ValRecord map =>
+    let* map' := assoc_update member val map in
+    mret (ValRecord map')
+  | _ => None
+  end.


### PR DESCRIPTION
This merges the work on Poulet4, the Coq formalisation of P4 semantics, into this repository in a way that preserves the commit history of the `cornell-netlab/poulet4` repo. 

The build is set up to compile the Coq development, extract it into OCaml, build that as an OPAM package and then have the main Petr4 build use that package. Bear in mind that the integration is still very much proof of concept at this stage; the only exported type is `Direction`.

I am not at all experienced in build systems for OCaml, so if there is a more idiomatic way to do this integration, please let me know.