### PR TITLE
Nominal externs

### DIFF
--- a/examples/checker_tests/good/recursive_extern.p4
+++ b/examples/checker_tests/good/recursive_extern.p4
@@ -1,0 +1,4 @@
+extern queue_t<X> {
+  queue_t();
+  void copy_from(queue_t<X> other_queue);
+}

--- a/lib/typed.ml
+++ b/lib/typed.ml
@@ -103,39 +103,38 @@ end = struct
 end
 
 and ExternType : sig
+  type t =
+    { name: string; }
+  [@@deriving sexp,show,yojson]
+
+  val eq : t -> t -> bool
+end = struct
+  type t =
+    { name: string; }
+  [@@deriving sexp,show,yojson]
+
+  let eq extern1 extern2 =
+    Base.String.equal extern1.name extern2.name
+end
+
+and ExternMethods : sig
   type extern_method =
     { name: string;
       typ: FunctionType.t; }
-    [@@deriving sexp,show,yojson]
+  [@@deriving sexp,show,yojson]
 
-  type t =
-    { type_params: string list;
-      methods: extern_method list }
-    [@@deriving sexp,show,yojson]
-
-  val eq : t -> t -> bool
+  type t = { type_params: string list;
+             methods: extern_method list }
+  [@@deriving sexp,show,yojson]
 end = struct
   type extern_method =
     { name: string;
       typ: FunctionType.t; }
-    [@@deriving sexp,show,yojson]
+  [@@deriving sexp,show,yojson]
 
-  type t =
-    { type_params: string list;
-      methods: extern_method list }
-    [@@deriving sexp,show,yojson]
-
-  let eq_em
-    { name=s1; typ=f1 }
-    { name=s2; typ=f2 } =
-    Base.String.equal s1 s2 &&
-    FunctionType.eq f1 f2
-
-  let eq
-    { type_params=s1; methods=m1 }
-    { type_params=s2; methods=m2 } =
-    Base.List.equal Base.String.equal s1 s2 &&
-    Base.List.equal eq_em m1 m2
+  type t = { type_params: string list;
+             methods: extern_method list }
+  [@@deriving sexp,show,yojson]
 end
 
 and IntType : sig


### PR DESCRIPTION
This pull request changes externs to be nominal so that we can allow recursive extern types for free. The main code changes are replacing the extern type with a simple `Extern {name}` type and pushing the types of methods into their own spot in the typechecker environment.

I'm not crazy about the setup of types. If an extern is generic, an instance has type  `SpecializedType {base = Extern {name}; args = targs}` (read as `(extern name)<targs>`). A lot of the code assumes that types in canonical form do not have a type application constructor, so I wrote some ugly workarounds to get this working. I'm going to see if I can push the type arguments into the Extern constructor before this gets merged, but I wanted to open a PR since this solution does pass all the tests.